### PR TITLE
improve OISST testing, switch to cloud storage as source, +

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Climatology"
 uuid = "9e9a4d37-2d2e-41e3-8b85-f7978328d9c7"
 authors = ["gaelforget <gforget@mit.edu>"]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -17,6 +17,7 @@ MeshArrays = "cb8c808f-1acf-59a3-9d2b-6e38d009f683"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RollingFunctions = "b0e4dd01-7b14-53d8-9b45-175a3e362653"
+STAC = "08e62803-e111-4f53-be9b-274ff296e9da"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package is currently focused on downloading, reading, visualizing, and anal
 ## Tutorial Notebooks
 
 - [Sea Surface Temperature](https://JuliaOcean.github.io/Climatology.jl/dev/examples/sst_anomaly_notebook.html) (➭ [code link](https://raw.githubusercontent.com/JuliaOcean/Climatology.jl/master/examples/OISST/sst_anomaly_notebook.jl))
+- [Sea Level Anomalies](https://JuliaOcean.github.io/Climatology.jl/dev/examples/SatelliteAltimetry.html) (➭ [code link](https://raw.githubusercontent.com/JuliaOcean/Climatology.jl/master/examples/SSH/SatelliteAltimetry.jl)) sea level anomaly maps derived from altimetry. Sources : NASA/PODAAC, CMEMS.
 - [Sea Level Time Series & Maps](https://JuliaOcean.github.io/Climatology.jl/dev/examples/NSLCT_notebook.html) (➭ [code link](https://raw.githubusercontent.com/JuliaOcean/Climatology.jl/master/examples/NSLCT/NSLCT_notebook.jl))
 - [Physical Ocean, Currents, & Climate](https://JuliaOcean.github.io/Climatology.jl/dev/examples/ECCO_standard_plots.html) (➭ [code link](https://raw.githubusercontent.com/JuliaOcean/Climatology.jl/master/examples/ECCO/ECCO_standard_plots.jl))
 - [Marine Ecosystems & Biogeochemistry](https://JuliaOcean.github.io/Climatology.jl/dev/examples/CBIOMES_climatology_plot.html) (➭ [code link](https://raw.githubusercontent.com/JuliaOcean/Climatology.jl/master/examples/CBIOMES/CBIOMES_climatology_plot.jl))

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Documenter, Climatology
 import MITgcm, MeshArrays, NCDatasets, Pkg
 import PlutoSliderServer, CairoMakie
-import Climatology: Downloads
+import Climatology: Downloads, DataDeps
 
 Pkg.precompile()
 
@@ -25,10 +25,8 @@ Climatology.ECCOdiags_add("release2")
 Climatology.ECCOdiags_add("OCCA2HR1")
 withenv(MeshArrays.interpolation_setup,"DATADEPS_ALWAYS_ACCEPT"=>true)
 
-#temporary fix, which should no longer be needed after 0.5.9 is released
-earth_jpg=joinpath(tempdir(),"Blue_Marble.jpg")
-url="https://upload.wikimedia.org/wikipedia/commons/5/56/Blue_Marble_Next_Generation_%2B_topography_%2B_bathymetry.jpg"
-!isfile(earth_jpg) ? Downloads.download(url,earth_jpg) : nothing
+earth_jpg=joinpath(MeshArrays.mydatadep("basemap_jpg1"),
+       "Blue_Marble_Next_Generation_%2B_topography_%2B_bathymetry.jpg")
 
 lst=("SSH/SatelliteAltimetry.jl",
      "OISST/sst_anomaly_notebook.jl","CBIOMES/CBIOMES_climatology_plot.jl",

--- a/examples/OISST/sst_anomaly_notebook.jl
+++ b/examples/OISST/sst_anomaly_notebook.jl
@@ -178,7 +178,7 @@ begin
     (fil1,fil2)=SST_FILES.file_lists(path=input_path)
 	list=SST_FILES.read_files_list(path=input_path)
     files_list=SST_processing.download_files(path=input_path,short_demo=true)
-	show(files_list)
+	display([input_path;basename.(files_list)])
 end
 
 # ╔═╡ 1632750d-0908-4b06-98dc-861101449fef
@@ -410,7 +410,6 @@ PLUTO_PROJECT_TOML_CONTENTS = """
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Climatology = "9e9a4d37-2d2e-41e3-8b85-f7978328d9c7"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
@@ -430,7 +429,7 @@ PLUTO_MANIFEST_TOML_CONTENTS = """
 
 julia_version = "1.10.5"
 manifest_format = "2.0"
-project_hash = "a5c624738f50b68dc75176dd2f88787db19ec324"
+project_hash = "543b842e4768414775b89564096416528d2d0e7d"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -2511,8 +2510,8 @@ version = "3.6.0+0"
 # ╟─882b8a60-ea87-11ed-3518-8db7b95f5a9f
 # ╟─044069e5-0d35-440e-9e62-561e11de6d18
 # ╟─2dcbb093-48f8-44cc-a756-c0c46f6d0844
-# ╠═c925f69f-6ecc-428e-aae1-0a2446baddb8
-# ╠═b548be7e-a0d6-4051-b3bd-2834cdd01ce4
-# ╠═3178b826-8f9d-4cf6-955f-c40887e15476
+# ╟─c925f69f-6ecc-428e-aae1-0a2446baddb8
+# ╟─b548be7e-a0d6-4051-b3bd-2834cdd01ce4
+# ╟─3178b826-8f9d-4cf6-955f-c40887e15476
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/examples/OISST/sst_anomaly_notebook.jl
+++ b/examples/OISST/sst_anomaly_notebook.jl
@@ -18,8 +18,8 @@ end
 begin
 	using Climatology, NCDatasets, CairoMakie, PlutoUI, Glob
 	
-    input_path=Climatology.SST_demo_path
-    #input_path="files"
+#    input_path=Climatology.SST_demo_path
+    input_path=tempname(); mkdir(input_path)
     input_path_ersst="files_ersst"
 	path_OISST_stats=Climatology.downloads.OISST_stats_download()
 
@@ -176,15 +176,15 @@ end
 # ╔═╡ 3178b826-8f9d-4cf6-955f-c40887e15476
 begin
     (fil1,fil2)=SST_FILES.file_lists(path=input_path)
-	list=SST_FILES.read_files_list(path=input_path)[1:length(unique(df.t)),:]
-    SST_processing.download_files(path=input_path,short_demo=true)
-	show(list)
+	list=SST_FILES.read_files_list(path=input_path)
+    files_list=SST_processing.download_files(path=input_path,short_demo=true)
+	show(files_list)
 end
 
 # ╔═╡ 1632750d-0908-4b06-98dc-861101449fef
 begin
-	tt=range(length(list.fil),step=-fil_del,length=30)
-	b_fil_sst = @bind fil_sst Select(list.fil[tt],default=list.fil[end])
+    tt=(length(files_list)>30 ? range(length(files_list),step=-fil_del,length=30) : tt=(1:length(files_list)))
+	b_fil_sst = @bind fil_sst Select(files_list[tt],default=files_list[end])
 	b_ano_sst = @bind ano_sst Select([true,false])
 	b_ano_ncei = @bind ano_ncei Select([true,false],default=false)
 	md"""
@@ -234,7 +234,7 @@ let
 end
 
 # ╔═╡ c925f69f-6ecc-428e-aae1-0a2446baddb8
-G=SST_coarse_grain.grid(list.fil[end])
+G=SST_coarse_grain.grid(files_list[end])
 
 # ╔═╡ 9ecb8f63-e8ac-4e5b-9078-356f7f434f2c
 begin
@@ -410,6 +410,7 @@ PLUTO_PROJECT_TOML_CONTENTS = """
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Climatology = "9e9a4d37-2d2e-41e3-8b85-f7978328d9c7"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
@@ -427,9 +428,9 @@ PlutoUI = "~0.7.52"
 PLUTO_MANIFEST_TOML_CONTENTS = """
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.4"
+julia_version = "1.10.5"
 manifest_format = "2.0"
-project_hash = "543b842e4768414775b89564096416528d2d0e7d"
+project_hash = "a5c624738f50b68dc75176dd2f88787db19ec324"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -470,9 +471,9 @@ weakdeps = ["StaticArrays"]
     AdaptStaticArraysExt = "StaticArrays"
 
 [[deps.AdaptivePredicates]]
-git-tree-sha1 = "7d5da5dd472490d048b081ca1bda4a7821b06456"
+git-tree-sha1 = "7e651ea8d262d2d74ce75fdf47c4d63c07dba7a6"
 uuid = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
-version = "1.1.1"
+version = "1.2.0"
 
 [[deps.AliasTables]]
 deps = ["PtrArrays", "Random"]
@@ -607,9 +608,9 @@ version = "1.1.0"
 
 [[deps.CairoMakie]]
 deps = ["CRC32c", "Cairo", "Cairo_jll", "Colors", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "PrecompileTools"]
-git-tree-sha1 = "361dec06290d76b6d70d0c7dc888038eec9df63a"
+git-tree-sha1 = "0852b8edf4da66cc44861b12d7d6c69693fc620f"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.12.9"
+version = "0.12.12"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -625,19 +626,19 @@ version = "1.0.0"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "71acdbf594aab5bbb2cec89b208c41b4c411e49f"
+git-tree-sha1 = "3e4b134270b372f2ed4d4d0e936aabaefc1802bc"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.24.0"
+version = "1.25.0"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
     ChainRulesCoreSparseArraysExt = "SparseArrays"
 
 [[deps.Climatology]]
-deps = ["CSV", "DataDeps", "DataFrames", "Dataverse", "Dates", "Distributed", "Glob", "JLD2", "MeshArrays", "Pkg", "Printf", "RollingFunctions", "Scratch", "SharedArrays", "Statistics", "TOML"]
-git-tree-sha1 = "7be17e70b225b87a35ff3d0df29c3d4ab1b3564b"
+deps = ["CSV", "DataDeps", "DataFrames", "DataStructures", "Dataverse", "Dates", "Distributed", "Glob", "JLD2", "MeshArrays", "Pkg", "Printf", "RollingFunctions", "Scratch", "SharedArrays", "Statistics", "TOML", "URIs"]
+git-tree-sha1 = "e6125cff3b1a00dc84f53f677ce1ba5a1dc9a580"
 uuid = "9e9a4d37-2d2e-41e3-8b85-f7978328d9c7"
-version = "0.5.8"
+version = "0.5.10"
 
     [deps.Climatology.extensions]
     ClimatologyMITgcmExt = ["MITgcm"]
@@ -766,10 +767,10 @@ uuid = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 version = "0.7.13"
 
 [[deps.DataFrames]]
-deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "REPL", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
+deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "fb61b4812c49343d7ef0b533ba982c46021938a6"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.6.1"
+version = "1.7.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -802,9 +803,9 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[deps.DelaunayTriangulation]]
 deps = ["AdaptivePredicates", "EnumX", "ExactPredicates", "Random"]
-git-tree-sha1 = "9903123ab7fc5e55053292aff04ff5d7aff92633"
+git-tree-sha1 = "90fe18ca4b73bdd2320fbbccec727a75069455f6"
 uuid = "927a84f5-c5f4-47a5-9785-b46e178433df"
-version = "1.3.0"
+version = "1.5.1"
 
 [[deps.DiskArrays]]
 deps = ["LRUCache", "OffsetArrays"]
@@ -829,9 +830,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "e6c693a0e4394f8fda0e51a5bdf5aef26f8235e9"
+git-tree-sha1 = "d7477ecdafb813ddee2ae727afa94e9dcb5f3fb0"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.111"
+version = "0.25.112"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -902,9 +903,9 @@ version = "1.8.0"
 
 [[deps.FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
+git-tree-sha1 = "4d81ed14783ec49ce9f2e168208a12ce1815aa25"
 uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
-version = "3.3.10+0"
+version = "3.3.10+1"
 
 [[deps.FTPClient]]
 deps = ["LibCURL", "URIParser"]
@@ -1013,9 +1014,9 @@ version = "0.4.2"
 
 [[deps.GeoInterface]]
 deps = ["Extents", "GeoFormatTypes"]
-git-tree-sha1 = "5921fc0704e40c024571eca551800c699f86ceb4"
+git-tree-sha1 = "2f6fce56cdb8373637a6614e14a5768a88450de2"
 uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
-version = "1.3.6"
+version = "1.3.7"
 
 [[deps.GeometryBasics]]
 deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
@@ -1095,9 +1096,9 @@ version = "0.1.17"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "5e19e1e4fa3e71b774ce746274364aef0234634e"
+git-tree-sha1 = "dd3b49277ec2bb2c6b94eb1604d4d0616016f7a6"
 uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
-version = "2.11.1+0"
+version = "2.11.2+0"
 
 [[deps.HypergeometricFunctions]]
 deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
@@ -1270,9 +1271,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "Requires", "TranscodingStreams"]
-git-tree-sha1 = "a0746c21bdc986d0dc293efa6b1faee112c37c28"
+git-tree-sha1 = "9b8b3233d4a611a68f6cbcba96049c8d6fd3de73"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.53"
+version = "0.5.4"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -1306,9 +1307,9 @@ version = "0.1.5"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "c84a835e1a09b289ffcd2271bf2a337bbdda6637"
+git-tree-sha1 = "25ee0be4d43d0269027024d75a24c24d6c6e590c"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.0.3+0"
+version = "3.0.4+0"
 
 [[deps.KahanSummation]]
 git-tree-sha1 = "6292e7878fe190651e74148edb11356dbbc2e194"
@@ -1329,9 +1330,9 @@ version = "3.100.2+0"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e16271d212accd09d52ee0ae98956b8a05c4b626"
+git-tree-sha1 = "78211fb6cbc872f77cad3fc0b6cf647d923f4929"
 uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
-version = "17.0.6+0"
+version = "18.1.7+0"
 
 [[deps.LRUCache]]
 git-tree-sha1 = "b3cc6698599b10e652832c2f23db3cab99d51b59"
@@ -1344,9 +1345,9 @@ weakdeps = ["Serialization"]
 
 [[deps.LZO_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "70c5da094887fd2cae843b8db33920bac4b6f07d"
+git-tree-sha1 = "854a9c268c43b77b0a27f22d7fab8d33cdb3a731"
 uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
-version = "2.10.2+0"
+version = "2.10.2+1"
 
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "50901ebc375ed41dbf8058da26f9de442febbbec"
@@ -1483,9 +1484,9 @@ version = "0.12.171"
 
 [[deps.Lz4_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7f26c8fc5229e68484e0b3447312c98e16207d11"
+git-tree-sha1 = "abf88ff67f4fd89839efcae2f4c39cbc4ecd0846"
 uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
-version = "1.10.0+0"
+version = "1.10.0+1"
 
 [[deps.MIMEs]]
 git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
@@ -1512,9 +1513,9 @@ version = "0.1.11"
 
 [[deps.MPItrampoline_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "8c35d5420193841b2f367e658540e8d9e0601ed0"
+git-tree-sha1 = "fde81c9f9c94fe5fbeaed7b3f1330305cf9a327c"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.4.0+0"
+version = "5.5.0+0"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
@@ -1523,16 +1524,16 @@ uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.13"
 
 [[deps.Makie]]
-deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageIO", "InteractiveUtils", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
-git-tree-sha1 = "204f06860af9008fa08b3a4842f48116e1209a2c"
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "e08a87ca672b6f26a6f7237000554d2a093d3495"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.21.9"
+version = "0.21.12"
 
 [[deps.MakieCore]]
 deps = ["ColorTypes", "GeometryBasics", "IntervalSets", "Observables"]
-git-tree-sha1 = "b0e2e3473af351011e598f9219afb521121edd2b"
+git-tree-sha1 = "22fed09860ca73537a36d4e5a9bce0d9e80ee8a8"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.8.6"
+version = "0.8.8"
 
 [[deps.ManualMemory]]
 git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
@@ -1566,10 +1567,10 @@ uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+1"
 
 [[deps.MeshArrays]]
-deps = ["CatViews", "Dates", "LazyArtifacts", "NearestNeighbors", "Pkg", "Printf", "SparseArrays", "Statistics", "Unitful"]
-git-tree-sha1 = "c1c5c8afde5293b643aea2d5ccc8554b1e593bf0"
+deps = ["CatViews", "Dates", "Distributed", "Glob", "LazyArtifacts", "NearestNeighbors", "Pkg", "Printf", "SharedArrays", "SparseArrays", "Statistics", "Unitful"]
+git-tree-sha1 = "9e23290eaf07436e7288ecac9899efd7f23c6e93"
 uuid = "cb8c808f-1acf-59a3-9d2b-6e38d009f683"
-version = "0.3.11"
+version = "0.3.16"
 
     [deps.MeshArrays.extensions]
     MeshArraysDataDepsExt = ["DataDeps"]
@@ -1626,9 +1627,9 @@ version = "1.0.2"
 
 [[deps.NearestNeighbors]]
 deps = ["Distances", "StaticArrays"]
-git-tree-sha1 = "91a67b4d73842da90b526011fa85c5c4c9343fe0"
+git-tree-sha1 = "3cebfc94a0754cc329ebc3bab1e6c89621e791ad"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.18"
+version = "0.4.20"
 
 [[deps.NetCDF_jll]]
 deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
@@ -1722,9 +1723,9 @@ version = "1.4.3"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1b35263570443fdd9e76c76b7062116e2f374ab8"
+git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.15+0"
+version = "3.0.15+1"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -1856,9 +1857,9 @@ version = "1.4.3"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "66b20dd35966a748321d3b2537c4584cf40387c7"
+git-tree-sha1 = "1101cd475833706e4d0e7b122218257178f48f34"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "2.3.2"
+version = "2.4.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -1883,9 +1884,9 @@ version = "1.0.0"
 
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "1d587203cf851a51bf1ea31ad7ff89eff8d625ea"
+git-tree-sha1 = "cda3b045cf9ef07a08ad46731f5a3165e56cf3da"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.11.0"
+version = "2.11.1"
 
     [deps.QuadGK.extensions]
     QuadGKEnzymeExt = "Enzyme"
@@ -1935,15 +1936,15 @@ version = "1.3.0"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "f65dcb5fa46aee0cf9ed6274ccbd597adc49aa7b"
+git-tree-sha1 = "852bd0f55565a9e973fcfee83a84413270224dc4"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.7.1"
+version = "0.8.0"
 
 [[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e60724fd3beea548353984dc61c943ecddb0e29a"
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.4.3+0"
+version = "0.5.1+0"
 
 [[deps.RollingFunctions]]
 deps = ["AccurateArithmetic", "FastBroadcast", "KahanSummation", "LinearAlgebra", "LoopVectorization", "Statistics", "StatsBase", "Tables"]
@@ -1962,9 +1963,9 @@ version = "0.7.0"
 
 [[deps.SIMD]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "2803cab51702db743f3fda07dd1745aadfbf43bd"
+git-tree-sha1 = "98ca7c29edd6fc79cd74c61accb7010a4e7aee33"
 uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
-version = "3.5.0"
+version = "3.6.0"
 
 [[deps.SIMDTypes]]
 git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
@@ -2015,9 +2016,9 @@ uuid = "73760f76-fbc4-59ce-8f25-708e95d2df96"
 version = "0.4.0"
 
 [[deps.SimpleBufferStream]]
-git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
 uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
-version = "1.1.0"
+version = "1.2.0"
 
 [[deps.SimpleTraits]]
 deps = ["InteractiveUtils", "MacroTools"]
@@ -2113,9 +2114,9 @@ version = "0.34.3"
 
 [[deps.StatsFuns]]
 deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "cef0472124fab0695b58ca35a77c6fb942fdab8a"
+git-tree-sha1 = "b423576adc27097764a90e163157bcfc9acf0f46"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "1.3.1"
+version = "1.3.2"
 
     [deps.StatsFuns.extensions]
     StatsFunsChainRulesCoreExt = "ChainRulesCore"
@@ -2133,9 +2134,9 @@ version = "0.5.7"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "a04cabe79c5f01f4d723cc6704070ada0b9d46d5"
+git-tree-sha1 = "a6b1675a536c5ad1a60e5a5153e1fee12eb146e3"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.3.4"
+version = "0.4.0"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -2374,9 +2375,9 @@ version = "1.2.13+1"
 
 [[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e678132f07ddb5bfa46857f0d7620fb9be675d3b"
+git-tree-sha1 = "555d1076590a6cc2fdee2ef1469451f872d8b41b"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.5.6+0"
+version = "1.5.6+1"
 
 [[deps.isoband_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -2405,7 +2406,7 @@ version = "0.15.2+0"
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+1"
+version = "5.11.0+0"
 
 [[deps.libfdk_aac_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2415,15 +2416,15 @@ version = "2.0.3+0"
 
 [[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "d7015d2e18a5fd9a4f47de711837e980519781a4"
+git-tree-sha1 = "b70c870239dc3d7bc094eb2d6be9b73d27bef280"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-version = "1.6.43+1"
+version = "1.6.44+0"
 
 [[deps.libsixel_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "libpng_jll"]
-git-tree-sha1 = "d4f63314c8aa1e48cd22aa0c17ed76cd1ae48c3c"
+git-tree-sha1 = "7dfa0fd9c783d3d0cc43ea1af53d69ba45c447df"
 uuid = "075b6546-f08a-558a-be8f-8157d0f608a5"
-version = "1.10.3+0"
+version = "1.10.3+1"
 
 [[deps.libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]

--- a/ext/ClimatologyMakieExt.jl
+++ b/ext/ClimatologyMakieExt.jl
@@ -241,10 +241,9 @@ module ClimatologyMakieExt
 	module SST_plots
 
 	using Makie
-	import Climatology: load, Statistics, SSTdiag, Downloads
+	import Climatology: load, Statistics, SSTdiag
+	import Climatology: MeshArrays, DataDeps
 	import Statistics: median
-
-#	using CairoMakie, Statistics, FileIO, Colors, Downloads
 	
 	#
 	
@@ -328,10 +327,9 @@ module ClimatologyMakieExt
 	end
 	
 	function map_base()
-		earth_jpg=joinpath(tempdir(),"Blue_Marble.jpg")
-		url="https://upload.wikimedia.org/wikipedia/commons/5/56/Blue_Marble_Next_Generation_%2B_topography_%2B_bathymetry.jpg"
-		!isfile(earth_jpg) ? Downloads.download(url,earth_jpg) : nothing
-	
+		earth_jpg=joinpath(MeshArrays.mydatadep("basemap_jpg1"),
+		"Blue_Marble_Next_Generation_%2B_topography_%2B_bathymetry.jpg") 
+		
 		earth_img=load(earth_jpg)
 		earth_img=reverse(permutedims(earth_img),dims=2)
 		earth_img=circshift(earth_img,(1800,0))

--- a/src/OISST.jl
+++ b/src/OISST.jl
@@ -326,11 +326,11 @@ import Dataverse.downloads: Downloads
 import Climatology: SST_FILES, SST_coarse_grain, read_Dataset
 import Climatology: SST_demo_path, to_monthly_file, write_SST_climatology
 
-function download_files(;path=SST_demo_path,short_demo=false)
+function download_files(;path=SST_demo_path,short_demo=false,verbose=false)
     !ispath(path) ? mkdir(path) : nothing
     fil,_=SST_FILES.file_lists(path=path)
     list=SST_FILES.read_files_list(path=path)
-    list=(short_demo ? list[end-9:end,:] : list)
+    list=(short_demo ? list[end-29:end,:] : list)
     n_per_workwer=Int(ceil(length(list.fil)/nworkers()))
 
     if !isempty(list.fil)
@@ -338,18 +338,18 @@ function download_files(;path=SST_demo_path,short_demo=false)
     @sync @distributed for m in 1:nworkers()
         n0=n_per_workwer*(m-1)+1
         n1=min(n_per_workwer*m,length(list.fil))
-        println("$(n0),$(n1)")
+        verbose ? println("$(n0),$(n1)") : nothing
         for r in eachrow(list[n0:n1,:])
             !isdir(dirname(r.fil)) ? mkdir(dirname(r.fil)) : nothing
             if !isfile(r.fil)
-            println(r.fil)
+            verbose ? println(r.fil) : nothing
             try
                 Downloads.download(r.url,r.fil)
             catch
                 try
                     Downloads.download(r.url[1:end-3]*"_preliminary.nc",r.fil[1:end-3]*"_preliminary.nc")
                 catch
-                    println("file not found online : "*r.fil[1:end-3])
+                    verbose ? println("file not found online : "*r.fil[1:end-3]) : nothing
                 end
             end
             end
@@ -358,7 +358,7 @@ function download_files(;path=SST_demo_path,short_demo=false)
 
     else
 
-    println("no more files to process")
+        verbose ? println("no more files to process") : nothing
 
     end
 
@@ -374,6 +374,7 @@ function download_files(;path=SST_demo_path,short_demo=false)
             tst[ll]=""
         end
     end
+
     tst[findall((!isempty).(tst))]
 
 end

--- a/src/OISST.jl
+++ b/src/OISST.jl
@@ -38,7 +38,8 @@ url="https://www.ncei.noaa.gov/thredds/fileServer/OisstBase/NetCDF/V2.1/AVHRR/19
 ```
 """
 function file_lists(;path=tempname())
-    url0="https://www.ncei.noaa.gov/thredds/fileServer/OisstBase/NetCDF/V2.1/AVHRR/"
+    #url0="https://www.ncei.noaa.gov/thredds/fileServer/OisstBase/NetCDF/V2.1/AVHRR/"
+    url0="https://noaa-cdr-sea-surface-temp-optimum-interpolation-pds.s3.amazonaws.com/data/v2.1/avhrr/"
 
     !ispath(path) ? mkdir(path) : nothing
     
@@ -346,9 +347,9 @@ function download_files(;path=SST_demo_path,short_demo=false)
                 Downloads.download(r.url,r.fil)
             catch
                 try
-                Downloads.download(r.url[1:end-3]*"_preliminary.nc",r.fil[1:end-3]*"_preliminary.nc")
+                    Downloads.download(r.url[1:end-3]*"_preliminary.nc",r.fil[1:end-3]*"_preliminary.nc")
                 catch
-                println("file not found online : "*r.fil[1:end-3])
+                    println("file not found online : "*r.fil[1:end-3])
                 end
             end
             end
@@ -360,6 +361,21 @@ function download_files(;path=SST_demo_path,short_demo=false)
     println("no more files to process")
 
     end
+
+    nl=length(list.fil)
+    tst=fill("",nl)
+    for ll in 1:nl
+        if isfile(list.fil[ll])
+            tst[ll]=list.fil[ll]
+        elseif isfile(list.fil[ll][1:end-3]*"_preliminary.nc")
+            list.fil[ll][1:end-3]*"_preliminary.nc"
+            tst[ll]=list.fil[ll][1:end-3]*"_preliminary.nc"
+        else
+            tst[ll]=""
+        end
+    end
+    tst[findall((!isempty).(tst))]
+
 end
 
 ## 
@@ -450,15 +466,16 @@ function calc(input,list; title="", gdf=nothing)
 	else
 		sst1=input[:]
 	end
-	sst2=repeatclim(sst1,list)
-	sst3=anom(sst1,list)
+    nt=size(sst1,1)
+    sst2=repeatclim(sst1,list[1:nt,:])
+	sst3=anom(sst1,list[1:nt,:])
 
 	ttl="SST time series"
 	#isa(input,DataFrames.GroupKey) ? ttl=ttl*"for i="*string(input.i)*", j="*string(input.j) : nothing 
 	!isempty(title) ?  ttl=title : nothing
 
     ts=(sst=sst1,clim=sst2,anom=sst3,title=ttl,
-    year=list.year,month=list.month,day=list.day)
+    year=list.year[1:nt],month=list.month[1:nt],day=list.day[1:nt])
 
     tmp1=calc_quantile(ts)
 

--- a/src/SSH.jl
+++ b/src/SSH.jl
@@ -9,15 +9,15 @@ import Base: read
 function read(x::SeaLevelAnomaly)
     ID=x.name
     path=x.path
-
-    DOI="doi:10.7910/DVN/OYBLGK"
-    lst=Dataverse.file_list(DOI)
     
     fil=string(ID)*".nc"
     sla_file=joinpath(path,fil)
     !isdir(path) ? mkdir(path) : nothing
-    !isfile(sla_file) ? Dataverse.file_download(lst,fil,path) : nothing
-    Dataverse.file_download(lst,fil,path)
+    if !isfile(sla_file)
+        DOI="doi:10.7910/DVN/OYBLGK"
+        lst=Dataverse.file_list(DOI)
+        Dataverse.file_download(lst,fil,path)
+    end
 
     ds=read_Dataset(sla_file)
     op=(dates=sla_dates(sla_file),)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,10 +42,10 @@ end
     list_pb=SST_FILES.test_files(whole_list)
     @test isa(list_pb,Vector)
 
-    (fil1,fil2)=SST_FILES.ersst_file_lists()
+    (fil1,fil2)=SST_FILES.ersst_file_lists(path=input_path)
     @test isfile(fil1)
 
-    (df,gdf,kdf)=SST_coarse_grain.lowres_read()
+    (df,gdf,kdf)=SST_coarse_grain.lowres_read(path=input_path)
 	kdf0=kdf[SST_coarse_grain.lowres_index(205,25,kdf)]
     (lon1,lat1)=SST_coarse_grain.lowres_position(kdf0.i,kdf0.j,kdf)
     #ts=SST_timeseries.calc(kdf0,whole_list,gdf=gdf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ end
 	(df,gdf,kdf)=SST_coarse_grain.lowres_read(fil="lowres_oisst_sst_$(dlon).csv",path=path_OISST_stats)
 
 	lon0=205; lat0=25
-	list=SST_FILES.read_files_list()[1:length(unique(df.t)),:]
+	list=SST_FILES.read_files_list(path=input_path)[1:length(unique(df.t)),:]
 
 	kdf0=kdf[SST_coarse_grain.lowres_index(lon0,lat0,kdf)]
 	(lon1,lat1)=SST_coarse_grain.lowres_position(kdf0.i,kdf0.j,kdf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,7 @@ end
     gr=SST_coarse_grain.grid(fil)
     @test isa(gr,NamedTuple)
 
-    list_pb=SST_FILES.test_files(list)
+    list_pb=SST_FILES.test_files(whole_list)
     @test isa(list_pb,Vector)
 
     (fil1,fil2)=SST_FILES.ersst_file_lists()
@@ -48,7 +48,7 @@ end
     (df,gdf,kdf)=SST_coarse_grain.lowres_read()
 	kdf0=kdf[SST_coarse_grain.lowres_index(205,25,kdf)]
     (lon1,lat1)=SST_coarse_grain.lowres_position(kdf0.i,kdf0.j,kdf)
-    #ts=SST_timeseries.calc(kdf0,list,gdf=gdf)
+    #ts=SST_timeseries.calc(kdf0,whole_list,gdf=gdf)
 
     @test isa(df,SST_FILES.DataFrame)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,9 +17,9 @@ end
 
     ## 1. SST
 
-    input_path=Climatology.SST_demo_path
+    input_path=tempname()
 
-    @suppress SST_processing.download_files(path=input_path,short_demo=true)
+    list_downloaded=SST_processing.download_files(path=input_path,short_demo=true)
     @test ispath(input_path)
 
     output_path=SST_processing.coarse_grain(path=input_path,short_demo=true)
@@ -30,9 +30,8 @@ end
     #mv(output_file,joinpath(input_path,basename(output_file)))
 
     (fil1,fil2)=SST_FILES.file_lists(path=input_path)
-    list=SST_FILES.CSV.read(fil1,SST_FILES.DataFrame)
-    fil=readdir(dirname(list.fil[end]))[1]
-    fil=joinpath(dirname(list.fil[end]),fil)
+    whole_list=SST_FILES.CSV.read(fil1,SST_FILES.DataFrame)
+    fil=list_downloaded[end]
 
     lon,lat=SST_FILES.read_lon_lat(fil)
     @test isa(lon,Vector)


### PR DESCRIPTION
- get OISST data from aws storage rather than thredds (which was interrupted by Hurricane Helene)
- make testing more robust (use temp folder), and resilient to delay (OISST)
- get basemap/blue marble via MeshArrays
